### PR TITLE
Add anchors in postfix class

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -11,9 +11,11 @@
 # == Sample Usage:
 #
 class postfix {
-  class { 'package': }
-  class { 'config': }
-  class { 'service': }
+  anchor { 'postfix::begin': } ->
+  class { 'package': }         ->
+  class { 'config': }          ->
+  class { 'service': }         ->
+  anchor { 'postfix::end': }
 
   if defined('monit') {
     monit::file { 'postfix': }


### PR DESCRIPTION
This pull requests adds anchors and class dependencies to the main postfix class. This way other classes can safely depend on it. See http://projects.puppetlabs.com/projects/puppet/wiki/Anchor_Pattern.
