### PR TITLE
Made relayhost optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,8 +307,8 @@ Determines which email address should be used for the redirecting. Defaults to "
 
 #### `relayhost`
 
-Determines which host should be used as relayhost for outgoing emails. Defaults
-to "smtp.${::domain}".
+Determines which host should be used as relayhost for outgoing emails. By default
+no relay host is set and e-mail is transmitted directly.
 
 #### `relayport`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -31,7 +31,7 @@ class postfix (
   $myhostname               = $::fqdn,
   $mydestination            = "${::fqdn}, localhost.${::domain}, localhost",
   $recipient                = "admin@${::domain}",
-  $relayhost                = "smtp.${::domain}",
+  $relayhost                = undef,
   $relayport                = 25,
   $sasl_user                = undef,
   $sasl_pass                = undef,

--- a/templates/Debian/etc/postfix/main.cf.erb
+++ b/templates/Debian/etc/postfix/main.cf.erb
@@ -48,7 +48,11 @@ alias_maps = hash:/etc/aliases
 alias_database = hash:/etc/aliases
 myorigin = /etc/mailname
 mydestination = <%= scope['::postfix::mydestination'] %>
+
+<% if scope['::postfix::relayhost'] -%>
 relayhost = [<%= scope['::postfix::relayhost'] -%>]:<%= scope['::postfix::relayport'] %>
+<% end -%>
+
 mynetworks = 127.0.0.0/8 [::ffff:127.0.0.0]/104 [::1]/128
 mailbox_command = procmail -a "$EXTENSION"
 mailbox_size_limit = 0

--- a/templates/Gentoo/etc/postfix/main.cf.erb
+++ b/templates/Gentoo/etc/postfix/main.cf.erb
@@ -325,7 +325,10 @@ mynetworks = 127.0.0.0/8 [::ffff:127.0.0.0]/104 [::1]/128
 #relayhost = [mailserver.isp.tld]
 #relayhost = uucphost
 #relayhost = [an.ip.add.ress]
-relayhost = <%= scope.lookupvar('::postfix::relayhost') %>
+#
+<% if scope['::postfix::relayhost'] -%>
+relayhost = [<%= scope['::postfix::relayhost'] -%>]:<%= scope['::postfix::relayport'] %>
+<% end -%>
 
 # REJECTING UNKNOWN RELAY USERS
 #

--- a/templates/Ubuntu/etc/postfix/main.cf.erb
+++ b/templates/Ubuntu/etc/postfix/main.cf.erb
@@ -51,7 +51,11 @@ alias_maps = hash:/etc/aliases
 alias_database = hash:/etc/aliases
 myorigin = /etc/mailname
 mydestination = <%= scope['::postfix::mydestination'] %>
+
+<% if scope['::postfix::relayhost'] -%>
 relayhost = [<%= scope['::postfix::relayhost'] -%>]:<%= scope['::postfix::relayport'] %>
+<% end -%>
+
 mynetworks = 127.0.0.0/8 [::ffff:127.0.0.0]/104 [::1]/128
 mailbox_size_limit = 0
 recipient_delimiter = +


### PR DESCRIPTION
This patch makes relayhost optional - and defaults to send mails without using a relay host.